### PR TITLE
Doc upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,11 +108,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-travis"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "cargo 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -287,6 +288,11 @@ dependencies = [
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -954,6 +960,7 @@ dependencies = [
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fs2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ab76cfd2aaa59b7bf6688ad9ba15bbae64bff97f04ea02144cfd3443e5c2866"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-zircon 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd510087c325af53ba24f3be8f1c081b0982319adcb8b03cad764512923ccc19"
 "checksum fuchsia-zircon-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "08b3a6f13ad6b96572b53ce7af74543132f1a7055ccceb6d073dd36c54481859"
 "checksum git2 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "40a111aecd59985496012976beca164b4f6c930d507a099831e06b07f19d54f1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["cargo", "cargo-subcommand", "travis", "coverage", "coveralls"]
 [dependencies]
 cargo = "0.22"
 env_logger = "0.4"
+fs_extra = "1.1"
 log = "0.3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -87,13 +87,13 @@ fn main() {
         }
     };
     let result = (|| {
-        let args: Vec<String> = env::args_os()
+        let args: Vec<String> = try!(env::args_os()
             .map(|s| {
                 s.into_string().map_err(|s| {
                     CargoError::from(format!("invalid unicode in argument: {:?}", s))
                 })
             })
-            .collect()?;
+            .collect());
         let rest = &args;
         cargo::call_main_without_stdin(execute, &config, USAGE, rest, false)
     })();

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -61,12 +61,14 @@ fn execute(options: Options, _: &Config) -> CliResult {
         return Ok(());
     }
 
-    // FEAT: Allow passing origin string
+    // TODO FEAT: Allow passing origin string
     let token = options.flag_token.or(env::var("GH_TOKEN").ok());
     let slug = env::var("TRAVIS_REPO_SLUG").expect("$TRAVIS_REPO_SLUG not set");
     let origin = if let Some(token) = token {
         format!("https://{}@github.com/{}.git", token, slug)
     } else {
+        eprintln!("GitHub Personal Access Token was not provided in $GH_TOKEN or --token");
+        eprintln!("Falling back to using the SSH endpoint");
         format!("git@github.com:{}.git", slug)
     };
 

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -1,0 +1,104 @@
+extern crate cargo;
+extern crate cargo_travis;
+extern crate env_logger;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate log;
+
+use std::env;
+use cargo::util::{CargoError, Config, CliResult};
+
+pub const USAGE: &'static str = ("
+Upload built rustdoc documentation to GitHub pages.
+
+Usage:
+    cargo doc-upload [options] [--] [<args>...]
+
+Options:
+    -V, --version                Print version info and exit
+    --branch NAME ...            Only publish documentation for these branches
+                                 Defaults to only the `master` branch
+    --token TOKEN                Use the specified GitHub token to publish documentation
+                                 If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
+    --message MESSAGE            The message to include in the commit
+    --deploy BRANCH              Deploy to the given branch [default: gh-pages]
+");
+
+#[derive(Deserialize)]
+pub struct Options {
+    flag_version: bool,
+    flag_branch: Vec<String>,
+    flag_token: Option<String>,
+    flag_message: Option<String>,
+    flag_deploy: Option<String>,
+}
+
+fn execute(options: Options, _: &Config) -> CliResult {
+    debug!("executing; cmd=cargo-doc-upload; env={:?}",
+           env::args().collect::<Vec<_>>());
+
+    if options.flag_version {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let branches = if options.flag_branch.is_empty() {
+        vec!["master".to_string()]
+    } else {
+        options.flag_branch
+    };
+
+    let branch = env::var("TRAVIS_BRANCH").expect("$TRAVIS_BRANCH not set");
+    if !branches.contains(&branch) {
+        println!("Skipping branch {}", branch);
+        return Ok(());
+    }
+
+    let pull_request = env::var("TRAVIS_PULL_REQUEST").expect("$TRAVIS_PULL_REQUEST not set");
+    if pull_request != "false" {
+        println!("Skipping PR");
+        return Ok(());
+    }
+
+    // FEAT: Allow passing origin string
+    let token = options.flag_token.or(env::var("GH_TOKEN").ok());
+    let slug = env::var("TRAVIS_REPO_SLUG").expect("$TRAVIS_REPO_SLUG not set");
+    let origin = if let Some(token) = token {
+        format!("https://{}@github.com/{}.git", token, slug)
+    } else {
+        format!("git@github.com:{}.git", slug)
+    };
+
+    let message = options.flag_message.unwrap_or("Automatic Travis documentation build".to_string());
+    let gh_pages = options.flag_deploy.unwrap_or("gh-pages".to_string());
+
+    cargo_travis::doc_upload(&branch, &message, &origin, &gh_pages);
+    Ok(())
+}
+
+fn main() {
+    env_logger::init().unwrap();
+    let config = match Config::default() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            let mut shell = cargo::core::Shell::new();
+            cargo::exit_with_error(e.into(), &mut shell)
+        }
+    };
+    let result = (|| {
+        let args: Vec<String> = env::args_os()
+            .map(|s| {
+                s.into_string().map_err(|s| {
+                    CargoError::from(format!("invalid unicode in argument: {:?}", s))
+                })
+            })
+            .collect()?;
+        let rest = &args;
+        cargo::call_main_without_stdin(execute, &config, USAGE, rest, false)
+    })();
+    match result {
+        Err(e) => cargo::exit_with_error(e, &mut *config.shell()),
+        Ok(()) => {}
+    }
+}


### PR DESCRIPTION
The functionality is there and should work with `cargo_travis::doc_upload`, but I was unable to figure out how to test the binary.

Closes #22 

I need to write up a bit about how to use it, but the simple+short version is:

- In Travis script, generate all documentation to `target/doc` (the default location). The file hierarchy you create there will be maintained, so if you want to doc different features, put them in sub-directories
- In Travis after_success, call `cargo doc-upload`. Have `$GH_TOKEN` set securely in your Travis configuration, and documentation will be built and uploaded for each test done on your `master` branch.