### PR TITLE
Build kcov in target dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-travis"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "cargo 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -74,14 +74,26 @@ Usage:
     cargo coverage [options] [--] [<args>...]
 
 Coverage Options:
+    -V, --version                Print version info and exit
     -m PATH, --merge-into PATH   Path to the directory to put the final merged
                                  kcov result into [default: target/kcov]
+    --exclude-pattern PATTERN    Comma-separated path patterns to exclude from the report
+    --kcov-build-location PATH   Path to the directory in which to build kcov (into a new folder)
+                                 [default: target] -- kcov ends up in target/kcov-master
+
 Test Options:
     -h, --help                   Print this message
     --lib                        Test only this package's library
     --bin NAME                   Test only the specified binary
+    --bins                       Test all binaries
     --test NAME                  Test only the specified integration test target
+    --tests                      Test all tests
+    --bench NAME ...             Test only the specified bench target
+    --benches                    Test all benches
+    --all-targets                Test all targets (default)
     -p SPEC, --package SPEC ...  Package to run tests for
+    --all                        Test all packages in the workspace
+    --exclude SPEC ...           Exclude packages from the test
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
@@ -95,6 +107,7 @@ Test Options:
     --no-fail-fast               Run all tests regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
+    -Z FLAG ...                  Unstable (nightly-only) flags to Cargo
 ```
 
 ### `coveralls`
@@ -106,12 +119,25 @@ but not doc tests. The results of all tests are sent to coveralls.io
 Usage:
     cargo coveralls [options] [--] [<args>...]
 
+Coveralls Options:
+    -V, --version                Print version info and exit
+    --exclude-pattern PATTERN    Comma-separated  path patterns to exclude from the report
+    --kcov-build-location PATH   Path to the directory in which to build kcov (into a new folder)
+                                 [default: target] -- kcov ends up in target/kcov-master
+
 Test Options:
     -h, --help                   Print this message
     --lib                        Test only this package's library
     --bin NAME                   Test only the specified binary
+    --bins                       Test all binaries
     --test NAME                  Test only the specified integration test target
+    --tests                      Test all tests
+    --bench NAME ...             Test only the specified bench target
+    --benches                    Test all benches
+    --all-targets                Test all targets (default)
     -p SPEC, --package SPEC ...  Package to run tests for
+    --all                        Test all packages in the workspace
+    --exclude SPEC ...           Exclude packages from the test
     -j N, --jobs N               Number of parallel jobs, defaults to # of CPUs
     --release                    Build artifacts in release mode, with optimizations
     --features FEATURES          Space-separated list of features to also build
@@ -125,6 +151,7 @@ Test Options:
     --no-fail-fast               Run all tests regardless of failure
     --frozen                     Require Cargo.lock and cache are up to date
     --locked                     Require Cargo.lock is up to date
+    -Z FLAG ...                  Unstable (nightly-only) flags to Cargo
 ```
 
 ### `doc-upload`

--- a/src/bin/cargo-coverage.rs
+++ b/src/bin/cargo-coverage.rs
@@ -25,6 +25,8 @@ Coverage Options:
     -m PATH, --merge-into PATH   Path to the directory to put the final merged
                                  kcov result into [default: target/kcov]
     --exclude-pattern PATTERN    Comma-separated path patterns to exclude from the report
+    --kcov-build-location PATH   Path to the directory in which to build kcov (into a new folder)
+                                 [default: target] -- kcov ends up in target/kcov-master
 
 Test Options:
     -h, --help                   Print this message
@@ -89,7 +91,8 @@ pub struct Options {
 
     // cargo-coverage flags
     flag_exclude_pattern: Option<String>,
-    flag_merge_into: String
+    flag_merge_into: String,
+    flag_kcov_build_location: String,
 }
 
 fn execute(options: Options, config: &Config) -> CliResult {
@@ -101,7 +104,7 @@ fn execute(options: Options, config: &Config) -> CliResult {
         return Ok(());
     }
 
-    let kcov_path = build_kcov();
+    let kcov_path = build_kcov(options.flag_kcov_build_location);
     // TODO: build_kcov() - Might be a good idea to consider linking kcov as a
     // lib instead ?
     try!(config.configure(options.flag_verbose,

--- a/src/bin/cargo-coveralls.rs
+++ b/src/bin/cargo-coveralls.rs
@@ -23,6 +23,8 @@ Usage:
 Coveralls Options:
     -V, --version                Print version info and exit
     --exclude-pattern PATTERN    Comma-separated  path patterns to exclude from the report
+    --kcov-build-location PATH   Path to the directory in which to build kcov (into a new folder)
+                                 [default: target] -- kcov ends up in target/kcov-master
 
 Test Options:
     -h, --help                   Print this message
@@ -87,6 +89,7 @@ pub struct Options {
 
     // cargo-coveralls flags
     flag_exclude_pattern: Option<String>,
+    flag_kcov_build_location: String,
 }
 
 fn execute(options: Options, config: &Config) -> CliResult {
@@ -98,7 +101,7 @@ fn execute(options: Options, config: &Config) -> CliResult {
         return Ok(());
     }
 
-    let kcov_path = build_kcov();
+    let kcov_path = build_kcov(options.flag_kcov_build_location);
     // TODO: build_kcov() - Might be a good idea to consider linking kcov as a
     // lib instead ?
     try!(config.configure(options.flag_verbose,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate cargo;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::ffi::{OsString};
+use std::fs;
 use cargo::core::{Workspace};
 use cargo::ops::{CompileOptions};
 use cargo::util::{CargoError, CargoErrorKind, CargoTestError, Test};
@@ -107,7 +108,8 @@ pub fn run_coverage(ws: &Workspace, options: &CoverageOptions, test_args: &[Stri
     }
 }
 
-pub fn build_kcov() -> PathBuf {
+pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
+    // If kcov is in path
     if let Some(paths) = std::env::var_os("PATH") {
         for path in std::env::split_paths(&paths) {
             if path.join("kcov").exists() {
@@ -115,47 +117,62 @@ pub fn build_kcov() -> PathBuf {
             }
         }
     }
-    if Path::new("kcov/build/src/kcov").exists() {
-        return std::env::current_dir().unwrap().join("kcov/build/src/kcov");
-    }
 
-    let mut init = String::new();
-
-    init.push_str(r"
-    rm -rf master.zip kcov-master kcov
-    wget https://github.com/SimonKagstrom/kcov/archive/master.zip
-    unzip master.zip
-    mv kcov-master kcov
-    mkdir -p kcov/build
-    ");
-
-    for line in init.split("\n") {
-        let line = line.trim();
-        if !line.is_empty() {
-            println!("Running: {:?}", line);
-            let tokens: Vec<_> = line.split(" ").collect();
-            let status = Command::new(tokens[0]).args(&tokens[1..]).status().unwrap();
-            if !status.success() {
-                process::exit(status.code().unwrap());
-            }
+    // TODO: Deduplicate this with the one in doc_upload
+    fn require_success(status: process::ExitStatus) {
+        if !status.success() {
+            process::exit(status.code().unwrap())
         }
     }
 
-    let build = r"
-        cmake ..
-        make
-    ";
-    for line in build.split("\n") {
-        let line = line.trim();
-        if !line.is_empty() {
-            println!("Running: {:?}", line);
-            let tokens: Vec<_> = line.split(" ").collect();
-            let status = Command::new(tokens[0]).args(&tokens[1..]).current_dir("kcov/build").status().unwrap();
-            if !status.success() {
-                process::exit(status.code().unwrap());
-            }
-        }
+    let kcov_dir: &Path = kcov_dir.as_ref();
+    let kcov_master_dir = kcov_dir.join("kcov-master");
+    let kcov_build_dir = kcov_master_dir.join("build");
+    let kcov_built_path = kcov_build_dir.join("src/kcov");
+
+    // If we already built kcov
+    if kcov_built_path.exists() {
+        return kcov_built_path;
     }
 
-    std::env::current_dir().unwrap().join("kcov/build/src/kcov")
+    // Download kcov
+    println!("Downloading kcov");
+    require_success(
+        Command::new("wget")
+            .current_dir(kcov_dir)
+            .arg("https://github.com/SimonKagstrom/kcov/archive/master.zip")
+            .status()
+            .unwrap()
+    );
+
+    // Extract kcov
+    println!("Extracting kcov");
+    require_success(
+        Command::new("unzip")
+            .current_dir(kcov_dir)
+            .arg("master.zip")
+            .status()
+            .unwrap()
+    );
+
+    // Build kcov
+    fs::create_dir(&kcov_build_dir);
+    println!("CMaking kcov");
+    require_success(
+        Command::new("cmake")
+            .current_dir(&kcov_build_dir)
+            .arg("..")
+            .status()
+            .unwrap()
+    );
+    println!("Making kcov");
+    require_success(
+        Command::new("make")
+            .current_dir(&kcov_build_dir)
+            .status()
+            .unwrap()
+    );
+
+    assert!(kcov_build_dir.exists());
+    kcov_built_path
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate cargo;
 extern crate fs_extra;
 
-use std::path::{self, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::ffi::{OsString};
 use std::fs;
@@ -109,6 +109,12 @@ pub fn run_coverage(ws: &Workspace, options: &CoverageOptions, test_args: &[Stri
     }
 }
 
+fn require_success(status: process::ExitStatus) {
+    if !status.success() {
+        process::exit(status.code().unwrap())
+    }
+}
+
 pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     // If kcov is in path
     if let Some(paths) = std::env::var_os("PATH") {
@@ -116,13 +122,6 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
             if path.join("kcov").exists() {
                 return path.join("kcov");
             }
-        }
-    }
-
-    // TODO: Deduplicate this with the one in doc_upload
-    fn require_success(status: process::ExitStatus) {
-        if !status.success() {
-            process::exit(status.code().unwrap())
         }
     }
 
@@ -179,13 +178,7 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
 }
 
 pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str) {
-    fn require_success(status: process::ExitStatus) {
-        if !status.success() {
-            process::exit(status.code().unwrap())
-        }
-    }
-
-    let doc_upload = path::Path::new("target/doc-upload");
+    let doc_upload = Path::new("target/doc-upload");
     if !doc_upload.exists() {
         // If the folder doesn't exist, clone it from remote
         // ASSUME: if target/doc-upload exists, it's ours
@@ -233,7 +226,7 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str) {
         }
     }
 
-    let doc = path::Path::new("target/doc");
+    let doc = Path::new("target/doc");
     println!("cp {} {}", doc.to_string_lossy(), doc_upload_branch.to_string_lossy());
     let mut last_progress = 0;
     fs_extra::copy_items_with_progress(


### PR DESCRIPTION
Should close roblabla/cargo-travis#6

With `after_success` usage, doesn't get cached, however. The cache gets stored before the `after_success` scripts are run.