### PR TITLE
prevent non-terminating kcov extraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     require_success(
         Command::new("unzip")
             .current_dir(kcov_dir)
+            .arg("-o")
             .arg("master.zip")
             .status()
             .unwrap()


### PR DESCRIPTION
The `-o` flag prevents prompting by `unzip`.