### PR TITLE
Preserve existing RUSTFLAGS and add debuginfo in --release mode

### DIFF
--- a/src/bin/cargo-coverage.rs
+++ b/src/bin/cargo-coverage.rs
@@ -133,10 +133,6 @@ fn execute(options: Options, config: &Config) -> CliResult {
 
     let spec = try!(Packages::from_flags(ws.is_virtual(), options.flag_all, &options.flag_exclude, &options.flag_package));
 
-    // TODO: Shouldn't this be in run_coverage ?
-    // TODO: It'd be nice if there was a flag in compile_opts for this.
-    std::env::set_var("RUSTFLAGS", "-C link-dead-code");
-
     let ops = CoverageOptions {
         merge_dir: Path::new(&options.flag_merge_into),
         merge_args: vec![],

--- a/src/bin/cargo-coveralls.rs
+++ b/src/bin/cargo-coveralls.rs
@@ -130,10 +130,6 @@ fn execute(options: Options, config: &Config) -> CliResult {
 
     let spec = try!(Packages::from_flags(ws.is_virtual(), options.flag_all, &options.flag_exclude, &options.flag_package));
 
-    // TODO: Shouldn't this be in run_coverage ?
-    // TODO: It'd be nice if there was a flag in compile_opts for this.
-    std::env::set_var("RUSTFLAGS", "-C link-dead-code");
-
     let job_id = std::env::var_os("TRAVIS_JOB_ID")
         .expect("Environment variable TRAVIS_JOB_ID not found. This should be run from Travis");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,11 @@ pub fn run_coverage(ws: &Workspace, options: &CoverageOptions, test_args: &[Stri
     // RUSTFLAGS should be preserved as well (and should be put last, so that
     // they override any earlier repeats).
     let mut rustflags: std::ffi::OsString = "-C link-dead-code".into();
+    if options.compile_opts.release {
+        // In release mode, ensure that there's debuginfo in some form so that
+        // kcov has something to work with.
+        rustflags.push(" -C debuginfo=2");
+    }
     if let Some(existing) = std::env::var_os("RUSTFLAGS") {
         rustflags.push(" ");
         rustflags.push(existing);


### PR DESCRIPTION
See individual commit messages for a description of each.