### PR TITLE
Add `--path` to `doc-upload` to be able to customize path to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,13 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
+    --path PATH                  Use the specified Path to upload the documentation to
+                                 Defaults to `/$TRAVIS_BRANCH/` in the git repository
 ```
 
 The branch used for doc pushes _may_ be protected, as force-push is not used. Documentation is maintained per-branch
-in subdirectories, so `user.github.io/repo/master` is where the master branch's documentation lives. By default only
+in subdirectories, so `user.github.io/repo/PATH` is where the master branch's documentation lives. `PATH` is by
+default the name of the branch, you can overwrite that behavior by passing a custom path into `--path`. By default only
 master has documentation built, but you can build other branches' docs by passing any number of `--branch NAME`
 arguments (the presence of which _will_ disable the default master branch build). Documentation is deployed from
 `target/doc`, the default target for `rustdoc`, so make sure to run `cargo doc` before `cargo doc-upload`, and you can

--- a/README.md
+++ b/README.md
@@ -179,8 +179,7 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
-    --path PATH                  Use the specified Path to upload the documentation to
-                                 Defaults to `/$TRAVIS_BRANCH/` in the git repository
+    --path PATH                  Upload the documentation to the specified remote path [default: /$TRAVIS_BRANCH/]
 ```
 
 The branch used for doc pushes _may_ be protected, as force-push is not used. Documentation is maintained per-branch

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -74,7 +74,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
         return Ok(());
     }
 
-    let path = options.flag_path.unwrap_or(branch);
+    let path = options.flag_path.unwrap_or(branch.clone());
 
     // TODO FEAT: Allow passing origin string
     let token = options.flag_token.or(env::var("GH_TOKEN").ok());

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -23,7 +23,8 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
-    --path Path                  Use the specified Path to upload documentation to [default: /$TRAVIS_BRANCH/]
+    --path PATH                  Use the specified Path to upload documentation to
+                                 Defaults to `/$TRAVIS_BRANCH/`
 ");
 
 #[derive(Deserialize)]
@@ -63,7 +64,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
         return Ok(());
     }
 
-    let path = options.flag_path.unwrap_or_else(|| env::var("TRAVIS_BRANCH").expect("$TRAVIS_BRANCH not set"));
+    let path = options.flag_path.unwrap_or(branch);
 
     // TODO FEAT: Allow passing origin string
     let token = options.flag_token.or(env::var("GH_TOKEN").ok());

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -23,8 +23,8 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
-    --path PATH                  Use the specified Path to upload documentation to
-                                 Defaults to `/$TRAVIS_BRANCH/`
+    --path PATH                  Use the specified Path to upload the documentation to
+                                 Defaults to `/$TRAVIS_BRANCH/` in the git repository
 ");
 
 #[derive(Deserialize)]

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -80,7 +80,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
     let message = options.flag_message.unwrap_or("Automatic Travis documentation build".to_string());
     let gh_pages = options.flag_deploy.unwrap_or("gh-pages".to_string());
 
-    match cargo_travis::doc_upload(&branch, &message, &origin, &gh_pages, &path) {
+    match cargo_travis::doc_upload(&message, &origin, &gh_pages, &path) {
         Ok(..) => Ok(()),
         Err((string, err)) => Err(CliError::new(CargoError::from(string), err)),
     }

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -74,7 +74,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
         return Ok(());
     }
 
-    let path = options.flag_path.unwrap_or(branch.clone());
+    let path = options.flag_path.unwrap_or_else(|| branch.clone());
 
     // TODO FEAT: Allow passing origin string
     let token = options.flag_token.or(env::var("GH_TOKEN").ok());
@@ -95,7 +95,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
         .map(|v| Path::new("target").join(v).join("doc"))
         .unwrap_or(PathBuf::from("target/doc"));
 
-    match cargo_travis::doc_upload(&branch, &message, &origin, &gh_pages, &path, &local_doc_path, clobber_index) {
+    match cargo_travis::doc_upload(&message, &origin, &gh_pages, &path, &local_doc_path, clobber_index) {
         Ok(..) => Ok(()),
         Err((string, err)) => Err(CliError::new(err_msg(string), err)),
     }

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -23,8 +23,7 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
-    --path PATH                  Use the specified Path to upload the documentation to
-                                 Defaults to `/$TRAVIS_BRANCH/` in the git repository
+    --path PATH                  Upload the documentation to the specified remote path [default: /$TRAVIS_BRANCH/]
 ");
 
 #[derive(Deserialize)]

--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -23,6 +23,7 @@ Options:
                                  If unspecified, checks $GH_TOKEN then attempts to use SSH endpoint
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
+    --path Path                  Use the specified Path to upload documentation to [default: /$TRAVIS_BRANCH/]
 ");
 
 #[derive(Deserialize)]
@@ -32,6 +33,7 @@ pub struct Options {
     flag_token: Option<String>,
     flag_message: Option<String>,
     flag_deploy: Option<String>,
+    flag_path: Option<String>,
 }
 
 fn execute(options: Options, _: &Config) -> CliResult {
@@ -61,6 +63,8 @@ fn execute(options: Options, _: &Config) -> CliResult {
         return Ok(());
     }
 
+    let path = options.flag_path.unwrap_or_else(|| env::var("TRAVIS_BRANCH").expect("$TRAVIS_BRANCH not set"));
+
     // TODO FEAT: Allow passing origin string
     let token = options.flag_token.or(env::var("GH_TOKEN").ok());
     let slug = env::var("TRAVIS_REPO_SLUG").expect("$TRAVIS_REPO_SLUG not set");
@@ -75,7 +79,7 @@ fn execute(options: Options, _: &Config) -> CliResult {
     let message = options.flag_message.unwrap_or("Automatic Travis documentation build".to_string());
     let gh_pages = options.flag_deploy.unwrap_or("gh-pages".to_string());
 
-    cargo_travis::doc_upload(&branch, &message, &origin, &gh_pages);
+    cargo_travis::doc_upload(&message, &origin, &gh_pages, &path);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     kcov_built_path
 }
 
-pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str) {
+pub fn doc_upload(message: &str, origin: &str, gh_pages: &str, doc_path: &str) {
     let doc_upload = Path::new("target/doc-upload");
     if !doc_upload.exists() {
         // If the folder doesn't exist, clone it from remote
@@ -231,7 +231,7 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str) {
         }
     }
 
-    let doc_upload_branch = doc_upload.join(branch);
+    let doc_upload_branch = doc_upload.join(doc_path);
     fs::create_dir(&doc_upload_branch).ok(); // Create dir if not exists
     for entry in doc_upload_branch.read_dir().unwrap() {
         let dir = entry.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,12 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
 
 pub fn doc_upload(message: &str, origin: &str, gh_pages: &str, doc_path: &str) -> Result<(), (String, i32)> {
     let doc_upload = Path::new("target/doc-upload");
+    let doc_upload_branch = doc_upload.join(doc_path);
+
+    if !doc_upload_branch.starts_with(doc_upload) {
+        return Err(("Path passed in `--pasth` is outside the intended `target/doc-upload` folder".to_string(), 1));
+    }
+
     if !doc_upload.exists() {
         // If the folder doesn't exist, clone it from remote
         // ASSUME: if target/doc-upload exists, it's ours
@@ -236,7 +242,6 @@ pub fn doc_upload(message: &str, origin: &str, gh_pages: &str, doc_path: &str) -
         }
     }
 
-    let doc_upload_branch = doc_upload.join(doc_path);
     fs::create_dir(&doc_upload_branch).ok(); // Create dir if not exists
     for entry in doc_upload_branch.read_dir().unwrap() {
         let dir = entry.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, doc
     let doc_upload_branch = doc_upload.join(doc_path);
 
     if !doc_upload_branch.starts_with(doc_upload) {
-        return Err(("Path passed in `--pasth` is outside the intended `target/doc-upload` folder".to_string(), 1));
+        return Err(("Path passed in `--path` is outside the intended `target/doc-upload` folder".to_string(), 1));
     }
 
     if !doc_upload.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     kcov_built_path
 }
 
-pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, doc_path: &str) -> Result<(), (String, i32)> {
+pub fn doc_upload(message: &str, origin: &str, gh_pages: &str, doc_path: &str) -> Result<(), (String, i32)> {
     let doc_upload = Path::new("target/doc-upload");
     if !doc_upload.exists() {
         // If the folder doesn't exist, clone it from remote

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,9 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     kcov_built_path
 }
 
-pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, doc_path: &str, local_doc_path: &Path, clobber_index: bool) -> Result<(), (String, i32)> {
+pub fn doc_upload(message: &str, origin: &str, gh_pages: &str, doc_path: &str, local_doc_path: &Path, clobber_index: bool) -> Result<(), (String, i32)> {
     let doc_upload = Path::new("target/doc-upload");
-    let doc_upload_branch = doc_upload.join(doc_path);
+    let doc_upload_branch = doc_upload.join(doc_path).canonicalize().unwrap();
 
     if !doc_upload_branch.starts_with(doc_upload) {
         return Err(("Path passed in `--path` is outside the intended `target/doc-upload` folder".to_string(), 1));


### PR DESCRIPTION
A little customization option, I needed that because I want to put more things then just the documentation inside of `gh_pages/BRANCH/`.

Default behaviour stays the same.