### PR TITLE
Doc upload target

### DIFF
--- a/src/bin/cargo-doc-upload.rs
+++ b/src/bin/cargo-doc-upload.rs
@@ -14,13 +14,14 @@ use cargo::util::{Config, CliResult, CliError};
 use docopt::Docopt;
 use failure::err_msg;
 
-pub const USAGE: &'static str = ("
+pub const USAGE: &'static str = "
 Upload built rustdoc documentation to GitHub pages.
 
 Usage:
-    cargo doc-upload [options] [--] [<args>...]
+    cargo doc-upload [options]
 
 Options:
+    -h, --help                   Print this message
     -V, --version                Print version info and exit
     --branch NAME ...            Only publish documentation for these branches
                                  Defaults to only the `master` branch
@@ -29,7 +30,7 @@ Options:
     --message MESSAGE            The message to include in the commit
     --deploy BRANCH              Deploy to the given branch [default: gh-pages]
     --clobber-index              Delete `index.html` from repo
-");
+";
 
 #[derive(Deserialize)]
 pub struct Options {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub fn build_kcov<P: AsRef<Path>>(kcov_dir: P) -> PathBuf {
     kcov_built_path
 }
 
-pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, clobber_index: bool) -> Result<(), (String, i32)> {
+pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, local_doc_path: &Path, clobber_index: bool) -> Result<(), (String, i32)> {
     let doc_upload = Path::new("target/doc-upload");
     if !doc_upload.exists() {
         // If the folder doesn't exist, clone it from remote
@@ -254,7 +254,7 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, clo
         // Or a new one was generated
         if dir.file_name() != OsString::from("index.html")
             || clobber_index
-            || Path::new("target/doc/index.html").exists()
+            || local_doc_path.join("index.html").exists()
         {
             let path = dir.path();
             println!("rm -r {}", path.to_string_lossy());
@@ -287,7 +287,7 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, clo
         badge_status = version.clone();
     }
 
-    let doc = Path::new("target/doc");
+    let doc = local_doc_path;
     println!("cp {} {}", doc.to_string_lossy(), doc_upload_branch.to_string_lossy());
     let mut last_progress = 0;
 


### PR DESCRIPTION
Allows uploading the doc for a particular target. When building docs with --target, the resulting doc ends up in target/TRIPLE/doc.