### PR TITLE
Add `badge.json` for `shields.io` endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Options:
 
 The branch used for doc pushes _may_ be protected, as force-push is not used. Documentation is maintained per-branch
 in subdirectories, so `user.github.io/repo/master` is where the master branch's documentation lives. A badge is generated
-too, like [docs.rs](https://docs.rs/about), that is located at `user.github.io/repo/master/badge.svg`. By default only
+too, like [docs.rs](https://docs.rs/about), that is located at `user.github.io/repo/master/badge.svg`. Additionally a
+`badge.json` is generated, that corresponds to [shields.io's endpoint](https://shields.io/endpoint). By default only
 master has documentation built, but you can build other branches' docs by passing any number of `--branch NAME`
 arguments (the presence of which _will_ disable the default master branch build). Documentation is deployed from
 `target/doc`, the default target for `rustdoc`, so make sure to run `cargo doc` before `cargo doc-upload`, and you can

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,17 @@ pub fn doc_upload(branch: &str, message: &str, origin: &str, gh_pages: &str, loc
         println!("No documentation found to upload.");
         result = Err(("No documentation generated".to_string(), 1));
     }
+    
+    // make badge.json
+    let json = json!({
+        "schemaVersion": 1,
+        "label": "docs",
+        "message": badge_status,
+        "color": badge_color
+    });
+
+    let mut file = fs::File::create(doc_upload_branch.join("badge.json")).unwrap();
+    file.write_all(json.to_string().as_bytes()).unwrap();
 
     // make badge.svg
     let badge_options = BadgeOptions {


### PR DESCRIPTION
[Shields.io](https://shields.io/#/endpoint) finished their endpoint [implementation](https://github.com/badges/shields/pull/2473).

EDIT: https://github.com/badges/shields/issues/2838